### PR TITLE
feat: Spring Security 사용자 인증 구성 추가

### DIFF
--- a/src/main/java/com/think_different/think_different/config/webSecurity/CustomUserDetails.java
+++ b/src/main/java/com/think_different/think_different/config/webSecurity/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package com.think_different.think_different.config.webSecurity;
+
+import com.think_different.think_different.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getLoginId();
+    }
+
+    @Override
+    // 계정 자체가 만료되었는가?
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    // 계정이 잠겨있는가?
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    // 비밀번호가 만료되었는가?
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    // 이 계정 사용 가능한 상태인가?
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/think_different/think_different/config/webSecurity/CustomUserDetailsService.java
+++ b/src/main/java/com/think_different/think_different/config/webSecurity/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.think_different.think_different.config.webSecurity;
+
+import com.think_different.think_different.member.entity.Member;
+import com.think_different.think_different.member.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 아이디입니다."));
+
+        return new CustomUserDetails(member);
+    }
+}


### PR DESCRIPTION
`CustomUserDetails ` : Member를 Spring Security가 이해하는 사용자 형태(UserDetails)로 포장하는 클래스
`CustomUserDetailsService` : 로그인 시 입력된 loginId로 DB에서 Member를 찾고 그 결과 CustomUserDetails로 만들어 Security에게 돌려주는 클래스
따라서 DB에 있는 회원(Member)을 Security가 쓰는 표준 인터페이스(UserDetails)로 변환해서 Security가 비밀번호 비교/권한 체크. 세션 저장을 하게 만드는 구조이다.